### PR TITLE
Add check for 0 values  from cross section file when using readmatrix()

### DIFF
--- a/Chem/Photolysis/IntegrateJ.m
+++ b/Chem/Photolysis/IntegrateJ.m
@@ -107,6 +107,8 @@ if ischar(CSin)            %text file
         cs(zerojunk,:) = [];
     else
         cs = readmatrix(CSin);
+	zerojunk = cs(:,1) == 0; %sometimes get bad values from csv files
+        cs(zerojunk,:) = [];
     end
     
     wl_cs = cs(:,1);


### PR DESCRIPTION
For MATLAB version 9.6 and newer, when reading in cross section files, you must still check for an remove zero values, otherwise NaN values propagate into your J-value array.

This PR resolves #24.